### PR TITLE
Adds a scale parameter to the image

### DIFF
--- a/ASCIImage.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ASCIImage.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:ASCIImage.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Core/PARImage+ASCIIInput.h
+++ b/Core/PARImage+ASCIIInput.h
@@ -27,6 +27,7 @@ extern NSString * const ASCIIContextStrokeColor;
 extern NSString * const ASCIIContextLineWidth;
 extern NSString * const ASCIIContextShouldClose;
 extern NSString * const ASCIIContextShouldAntialias;
+extern NSString * const ASCIIContextScale;
 
 @interface PARImage (ASCIIInput)
 

--- a/Core/PARImage+ASCIIInput.h
+++ b/Core/PARImage+ASCIIInput.h
@@ -2,14 +2,7 @@
 //  Created by Charles Parnot on 5/29/13.
 //  Copyright (c) 2013 Charles Parnot. All rights reserved.
 
-
-extern NSString * const ASCIIContextShapeIndex;
-extern NSString * const ASCIIContextFillColor;
-extern NSString * const ASCIIContextStrokeColor;
-extern NSString * const ASCIIContextLineWidth;
-extern NSString * const ASCIIContextShouldClose;
-extern NSString * const ASCIIContextShouldAntialias;
-
+#import <Foundation/Foundation.h>
 
 // iOS
 #if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
@@ -28,8 +21,14 @@ extern NSString * const ASCIIContextShouldAntialias;
 #endif
 
 
-@interface PARImage (ASCIIInput)
+extern NSString * const ASCIIContextShapeIndex;
+extern NSString * const ASCIIContextFillColor;
+extern NSString * const ASCIIContextStrokeColor;
+extern NSString * const ASCIIContextLineWidth;
+extern NSString * const ASCIIContextShouldClose;
+extern NSString * const ASCIIContextShouldAntialias;
 
+@interface PARImage (ASCIIInput)
 
 /// @name Creating Images from ASCII Input
 

--- a/Core/PARImage+ASCIIInput.m
+++ b/Core/PARImage+ASCIIInput.m
@@ -11,6 +11,7 @@ NSString * const ASCIIContextStrokeColor        = @"ASCIIContextStrokeColor";
 NSString * const ASCIIContextLineWidth          = @"ASCIIContextLineWidth";
 NSString * const ASCIIContextShouldClose        = @"ASCIIContextShouldClose";
 NSString * const ASCIIContextShouldAntialias    = @"ASCIIContextShouldAntialias";
+NSString * const ASCIIContextScale              = @"ASCIIContextScale";
 
 
 #pragma mark - PARImage Cross-Platform Image Class
@@ -506,10 +507,14 @@ NSString * const ASCIIContextShouldAntialias    = @"ASCIIContextShouldAntialias"
     NSArray *strictRep = [self strictASCIIRepresentationFromLenientASCIIRepresentation:rep];
     NSArray *shapes = [self shapesFromNumbersInStrictASCIIRepresentation:strictRep];
     
+    NSMutableDictionary *imgContext = [NSMutableDictionary dictionary];
+    contextHandler(imgContext);
+    CGFloat scale = imgContext[ASCIIContextScale] ? [imgContext[ASCIIContextScale] doubleValue] : 1.0f;
+    
     // image size
     NSUInteger countRows = strictRep.count;
     NSUInteger countCols = [strictRep[0] length];
-    NSSize imageSize = NSMakeSize(countCols, countRows);
+    NSSize imageSize = NSMakeSize(countCols * scale, countRows * scale);
     
     // image is drawn using the block API, so we can handle @2x drawing in HiDPI
     NSImage *image = [NSImage imageWithSize:imageSize flipped:NO drawingHandler:^BOOL(NSRect dstRect)

--- a/Core/PARImage+ASCIIInput.m
+++ b/Core/PARImage+ASCIIInput.m
@@ -510,6 +510,8 @@ NSString * const ASCIIContextScale              = @"ASCIIContextScale";
     NSMutableDictionary *imgContext = [NSMutableDictionary dictionary];
     contextHandler(imgContext);
     CGFloat scale = imgContext[ASCIIContextScale] ? [imgContext[ASCIIContextScale] doubleValue] : 1.0f;
+    NSAffineTransform *scaleTransform = [NSAffineTransform new];
+    [scaleTransform scaleBy:scale];
     
     // image size
     NSUInteger countRows = strictRep.count;
@@ -526,6 +528,7 @@ NSString * const ASCIIContextScale              = @"ASCIIContextScale";
               // ... but don't let the handler mess up the graphics context
               NSMutableDictionary *contextASCII = [NSMutableDictionary dictionaryWithDictionary:@{ASCIIContextShapeIndex: @(shapeIndex)}];
               [[NSGraphicsContext currentContext] saveGraphicsState];
+              
               {
                   contextHandler(contextASCII);
               }
@@ -540,7 +543,7 @@ NSString * const ASCIIContextScale              = @"ASCIIContextScale";
               
               // bezier path from shape
               PARBezierPath *path = shouldClose ? [shape closedBezierPath] : [shape bezierPath];
-
+              [path transformUsingAffineTransform:scaleTransform];
               // draw!
               [[NSGraphicsContext currentContext] saveGraphicsState];
               {


### PR DESCRIPTION
- Adds an optional relative scale parameter to the image context handler.
- Also fixes a compilation error in a scenario where source is being built without Foundation.h coming in via prefix header.
